### PR TITLE
Use `branch` instead of `checkout -b`

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,10 @@ Since rebasing **replaces the old commit(s) with a new one**, you must force pus
 ## I committed to master instead of a new branch
 
 
-Check out a new branch, then return to your master branch
+Create the new branch while remaining on master:
 
 ```
-(master)$ git checkout -b new-branch 
-(new-branch)$ git checkout master
-(master)$
+(master)$ git branch new-branch 
 ```
 
 Find out what the commit hash you want to set your master branch to (`git log` should do the trick). Then reset to that hash.
@@ -207,6 +205,12 @@ For example, if the hash of the commit that your master branch is supposed to be
 ```
 (master)$ git reset --hard a13b85e
 HEAD is now at a13b85e
+```
+
+Checkout the new branch to continue working:
+
+```
+(master)$ git checkout new-branch
 ```
 
 <a name="cherry-pick"></a>


### PR DESCRIPTION
Using `checkout -b` to create a new branch only to immediately checkout the previous branch is kind of pointless.
