### PR TITLE
`git reset --hard master~1` rather than `git reset --hard a13b85e`

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Create the new branch while remaining on master:
 Reset the branch master to the previous commit:
 
 ```
-(master)$ git reset --hard master~1
+(master)$ git reset --hard HEAD^
 ```
 
 Checkout the new branch to continue working:

--- a/README.md
+++ b/README.md
@@ -223,13 +223,10 @@ Create the new branch while remaining on master:
 (master)$ git branch new-branch 
 ```
 
-Find out what the commit hash you want to set your master branch to (`git log` should do the trick). Then reset to that hash.
-
-For example, if the hash of the commit that your master branch is supposed to be at is `a13b85e`:
+Reset the branch master to the previous commit:
 
 ```
-(master)$ git reset --hard a13b85e
-HEAD is now at a13b85e
+(master)$ git reset --hard master~1
 ```
 
 Checkout the new branch to continue working:


### PR DESCRIPTION
Using `git reset --hard master~1` rather than `git reset --hard a13b85e` to make the use of `git log` unnecessary

In the paragraph `commit-wrong-branch` you suggest to reset the branch `master` to its previous commit by using a `git log` and then resetting `master` to the `sha1` of the previous commit.

I think a simpler `git reset --hard master~1` is more convenient, since it saves the user from reading the output of `git log` and from copying the `sha1` of the commit.
