### PR TITLE
Fixed typographical error, changed accidentaly to accidentally in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Date:   Tue Jul 29 13:14:46 2014 -0400
     Fixes #6: Force pushing after amending commits
 ```
 
-Now we're switching back to master and 'accidentaly' removing our branch.
+Now we're switching back to master and 'accidentally' removing our branch.
 
 ```sh
 (my-branch)$ git checkout master


### PR DESCRIPTION
k88hudson, I've corrected a typographical error in the documentation of the [git-flight-rules](https://github.com/k88hudson/git-flight-rules) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.