### PR TITLE
Use 'branch' instead of 'checkout -b'

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,7 @@ One way of resetting to match origin (to have the same as what is on the remote)
 Create the new branch while remaining on master:
 
 ```sh
-(master)$ git checkout -b my-branch
-(my-branch)$ git checkout master
-(master)$
+(master)$ git branch my-branch
 ```
 
 Reset the branch master to the previous commit:


### PR DESCRIPTION
Referencing to [I committed to master instead of a new branch](https://github.com/k88hudson/git-flight-rules/blob/master/README.md#i-committed-to-master-instead-of-a-new-branch) here.

Instead of using

```
(master)$ git checkout -b my-branch
(my-branch)$ git checkout master
(master)$
```

just using

```
(master)$ git branch my-branch
```

works as well.

This was actually changed before in #21 but got mixed up a little. Now, not only are the commands somewhat repetitive, but also it's a little confusing because the explanation states  
> Create the new branch while remaining on master:

which is not exactly what is happening with these commands.
