### PR TITLE
Minor changes to removing the file from last commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ In order to remove a file from a commit, do the following:
 
 ```sh
 $ git checkout HEAD^ myfile
-$ git add -A
+$ git add myfile
 $ git commit --amend
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ In order to remove a file from a commit, do the following:
 ```sh
 $ git checkout HEAD^ myfile
 $ git add myfile
-$ git commit --amend
+$ git commit --amend --no-edit
 ```
 
 This is particularly useful when you have an open patch and you have committed an unnecessary file, and need to force push to update the patch on a remote.
+`--no-edit` option is used to keep the existing commit message.
 
 <a name="delete-pushed-commit"></a>
 ### I want to delete or remove my last commit


### PR DESCRIPTION
More specific removal of a file from a commit.

    git add -A

will add all the files, which might be undesirable, this may happen when `autoStash` is on.

To avoid editing the commit message again, a `--no-edit` may be used.