### PR TITLE
Removing -x on git clean tip to avoid unintentional use

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ This will remove all local untracked files, so only files tracked by Git remain:
 $ git clean -fd
 ```
 
-`-x` will also remove all ignored files!
+`-x` will also remove all ignored files.
 
 <a href="i-want-to-discard-specific-unstaged-changes"></a>
 ### I want to discard specific unstaged changes

--- a/README.md
+++ b/README.md
@@ -362,10 +362,10 @@ $ git reset --hard HEAD
 This will remove all local untracked files, so only files tracked by Git remain:
 
 ```sh
-$ git clean -fdx
+$ git clean -fd
 ```
 
-WARNING: -x will also remove all ignored files!
+`-x` will also remove all ignored files!
 
 <a href="i-want-to-discard-specific-unstaged-changes"></a>
 ### I want to discard specific unstaged changes
@@ -1405,7 +1405,7 @@ Using `git reset` it is then possible to change master back to the commit it was
 
 ## Tutorials
 
-* [Atlassian's Git tutorial](https://www.atlassian.com/git/tutorials) Get Git right with tutorials from beginner to advanced. 
+* [Atlassian's Git tutorial](https://www.atlassian.com/git/tutorials) Get Git right with tutorials from beginner to advanced.
 * [Learn Git branching](https://learngitbranching.js.org/) An interactive web based branching/merging/rebasing tutorial
 * [Getting solid at Git rebase vs. merge](https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa)
 * [git-workflow](https://github.com/asmeurer/git-workflow) - [Aaron Meurer](https://github.com/asmeurer)'s howto on using Git to contribute to open source repositories


### PR DESCRIPTION
This PR, as a suggestion, removes `-x` on `git clean` example. The motivation is to avoid unintentional use of command and lost the ignored files - some of us just copy and paste things.