### PR TITLE
Added test for TOC to .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ rvm:
   - 2.2
 before_script:
   - gem install awesome_bot
+  - npm install
 script:
 - awesome_bot README.md --allow-dupe --allow-redirect
 - awesome_bot README_*.md --allow-dupe --allow-redirect
+- node node_modules/doctoc/doctoc.js --github README.md README_*.md
+- test -z "`git diff -- README.md`"
+- test -z "`git diff -- README_*.md`"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "git-flight-rules",
+  "version": "1.0.0",
+  "description": "Flight rules for git",
+  "devDependencies": {
+    "doctoc": "^1.3.0",
+    "anchor-markdown-header": "thlorenz/anchor-markdown-header#master"
+  }
+}


### PR DESCRIPTION
Runs doctoc for README*.md.
If in newly doctoc'ed README*.md there are any diffs against ones commited in git HEAD then the test failes.
The script are using the latest anchor-markdown-header from repo to avoid the bug with non-ASCII headers.