### PR TITLE
Fix option to amend commit message

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -156,12 +156,12 @@ $ git log -n1 -p
 Si escribiste algo mal y todavía no has subido tu commit, puedes hacer lo siguiente para cambiar el mensaje del commit:
 
 ```sh
-$ git commit --amend
+$ git commit --amend --only
 ```
 Esto abrirá tu editor de texto por defecto, donde puedes editar el mensaje. Por otro lado, tú puedes hacer todo esto con un solo comando:
 
 ```sh
-$ git commit --amend -m 'xxxxxxx'
+$ git commit --amend --only -m 'xxxxxxx'
 ```
 
 Si ya has subido tu commit, puedes corregirlo usando amend y luego forzar el push, pero esto no es recomendado.

--- a/README_kr.md
+++ b/README_kr.md
@@ -178,13 +178,13 @@ $ git show <commitid>:filename
 만약 메시지를 잘못 썼고 아직 푸시를 안했다면, 커밋 메시지 바꾸기를 따라해 볼 수 있어요.
 
 ```sh
-$ git commit --amend
+$ git commit --amend --only
 ```
 
 이 방법은 편집 가능한 기본 텍스트 에디터가 열릴텐데요, 다른 방법으론 한줄에 쓸 수도 있어요.
 
 ```sh
-$ git commit --amend -m 'xxxxxxx'
+$ git commit --amend --only -m 'xxxxxxx'
 ```
 
 만약 푸시를 이미 했다면, 커밋을 수정해서 강제 푸시를 할 수 있긴한대 별로 추천하진 않아요.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -110,12 +110,12 @@ $ git log -n1 -p
 如果你的提交信息(commit message)写错了且这次提交(commit)还没有推(push), 你可以通过下面的方法来修改提交信息(commit message):
 
 ```sh
-$ git commit --amend
+$ git commit --amend --only
 ```
 这会打开你的默认编辑器, 在这里你可以编辑信息. 另一方面, 你也可以用一条命令一次完成:
 
 ```sh
-$ git commit --amend -m 'xxxxxxx'
+$ git commit --amend --only -m 'xxxxxxx'
 ```
 
 如果你已经推(push)了这次提交(commit), 你可以修改这次提交(commit)然后强推(force push), 但是不推荐这么做。


### PR DESCRIPTION
An example of original text in "[I wrote the wrong thing in a commit message](https://github.com/k88hudson/git-flight-rules#i-wrote-the-wrong-thing-in-a-commit-message)" chapter is following.

```sh
$ git commit --amend --only
```

But, others is following.
(--only option is none)

```sh
$ git commit --amend
```

So, I fixed to add ```--only``` option to all.

Please review!
