### PR TITLE
Fix "gim" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ A patch can be viewed and even edited by the recipient and applied using `git am
 
 For example, to create a patch based on the previous commit you would run `git format-patch HEAD^` which would create a .patch file called something like 0001-My-Commit-Message.patch.
 
-To apply this patch file to your repository you would run `gim am ./0001-My-Commit-Message.patch`.
+To apply this patch file to your repository you would run `git am ./0001-My-Commit-Message.patch`.
 
 Patches can also be sent via email using the `git send-email` command. For information on usage and configuration see: https://git-send-email.io
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -248,7 +248,7 @@ Các patch có thể được xem hoặc thậm chí thêm sửa bởi người 
 
 Ví dụ, để tạo patch dựa vào commit mới nhât, bạn chạy lệnh `git format-patch HEAD^`, lệnh sẽ tạo một tệp .patch với tên như: `0001-My-Commit-Message.patch`.
 
-Để áp gắn tệp patch cho repository, bạn sẽ dùng lệnh `gim am ./0001-My-Commit-Message.patch`.
+Để áp gắn tệp patch cho repository, bạn sẽ dùng lệnh `git am ./0001-My-Commit-Message.patch`.
 
 Các patch còn có thể gửi qua email với lệnh `git send-email`. Để xem thêm thông tin về cách dùng hoặc cấu hình, xem: https://git-send-email.io
 


### PR DESCRIPTION
I didn't notice this in any of the other translated files, which is why only one of them is being updated.