### PR TITLE
Update info how to reset local branch to remote-tracking branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,10 +903,10 @@ Confirm that you haven't pushed your changes to the server.
 #
 ```
 
-One way of resetting to match origin (to have the same as what is on the remote) is to do this:
+One way of resetting branch `my-branch` to match `origin/my-branch` (to have the same as what is on the remote) is to do this:
 
 ```sh
-(main)$ git reset --hard origin/my-branch
+(my-branch)$ git reset --hard origin/my-branch
 ```
 
 <a name="commit-wrong-branch"></a>

--- a/README_es.md
+++ b/README_es.md
@@ -515,7 +515,7 @@ Confirma que no ha enviado sus cambios al servidor.
 Una forma de reiniciar para hacer coincidir el origin (tener lo mismo que lo que está en el control remoto) es hacer esto:
 
 ```sh
-(main) $ git reset --hard origin / my-branch
+(my-branch) $ git reset --hard origin/my-branch
 ```
 
 ### Hice commit a main en lugar de una nueva rama

--- a/README_fr.md
+++ b/README_fr.md
@@ -576,7 +576,6 @@ Assurez-vous que vous n'avez pas poussé vos modifications sur le serveur.
 `git status` devrait vous indiquer combien de commits en avance vous êtes par rapport à origin :
 
 ```sh
-(my-branch)$ git status
 (ma-branche)$ git status
 # On branch ma-branche
 # Your branch is ahead of 'origin/my-branch' by 2 commits.
@@ -587,7 +586,7 @@ Assurez-vous que vous n'avez pas poussé vos modifications sur le serveur.
 Une des façons de faire pour réinitialiser votre branche afin qu'elle corresponde à origin (afin d'avoir la même chose que le dépôt distant) est de lancer ceci :
 
 ```sh
-(main)$ git reset --hard origin/ma-branche
+(ma-branche)$ git reset --hard origin/ma-branche
 ```
 
 <a name="commit-wrong-branch"></a>

--- a/README_ja.md
+++ b/README_ja.md
@@ -919,7 +919,7 @@ $ git reset --hard c5bc55a
 origin と同じ状態にリセットする（リモートと同じ状態にする）方法の一つは次の通りです。
 
 ```sh
-(main)$ git reset --hard origin/my-branch
+(my-branch)$ git reset --hard origin/my-branch
 ```
 
 <a name="commit-wrong-branch"></a>

--- a/README_kr.md
+++ b/README_kr.md
@@ -547,7 +547,7 @@ $ git reset --hard c5bc55a
 오리진(리모트과 같은 상태의)로 맞추는 리셋을 하는 방법 중 하나는:
 
 ```sh
-(main)$ git reset --hard origin/my-branch
+(my-branch)$ git reset --hard origin/my-branch
 ```
 
 <a name="commit-wrong-branch"></a>

--- a/README_ru.md
+++ b/README_ru.md
@@ -808,7 +808,7 @@ $ git reset --hard c5bc55a
 Один из способов сбросить до источника (чтобы иметь то же, что и в удаленном репозитории):
 
 ```sh
-(main)$ git reset --hard origin/my-branch
+(my-branch)$ git reset --hard origin/my-branch
 ```
 
 <a name="commit-wrong-branch"></a>

--- a/README_vi.md
+++ b/README_vi.md
@@ -853,7 +853,7 @@ Kiểm tra rằng bạn chưa push các thay đổi của mình đến server.
 Một cách để reset về origin (để có nhánh giống như trên remote) là chạy lệnh:
 
 ```sh
-(main)$ git reset --hard origin/my-branch
+(my-branch)$ git reset --hard origin/my-branch
 ```
 
 <a name="commit-wrong-branch"></a>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -376,7 +376,7 @@ $ git reset --hard c5bc55a
 一种方法是:
 
 ```sh
-(main)$ git reset --hard origin/my-branch
+(my-branch)$ git reset --hard origin/my-branch
 ```
 
 <a name="commit-wrong-branch"></a>

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -376,7 +376,7 @@ $ git reset --hard c5bc55a
 一種方法是:
 
 ```sh
-(main)$ git reset --hard origin/my-branch
+(my-branch)$ git reset --hard origin/my-branch
 ```
 
 <a name="commit-wrong-branch"></a>


### PR DESCRIPTION
If we are going to reset local branch `my-branch` to be like the remote repository `origin/my-branch`, the `HEAD` should be on the local branch we are going to reset. In the current situation the `HEAD` should be on the local branch `my-branch` (not the local branch `main` like in the example).

This is the current example:
```sh
(main)$ git reset --hard origin/my-branch
```
This is the fixed example:
```
(my-branch)$ git reset --hard origin/my-branch
```