### PR TITLE
Edits: changes in specific file between commits/branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1829,12 +1829,16 @@ Assuming you want to compare last commit with file from commit c5f567:
 
 ```sh
 $ git diff HEAD:path_to_file/file c5f567:path_to_file/file
+# or
+$ git diff HEAD c5f567 -- path_to_file/file
 ```
 
-Same goes for branches:
+If you are going to compare changes between the tips of the `main` and the `staging` branches:
 
 ```sh
 $ git diff main:path_to_file/file staging:path_to_file/file
+# or
+$ git diff main staging -- path_to_file/file
 ```
 
 ### I want Git to ignore changes to a specific file

--- a/README_fr.md
+++ b/README_fr.md
@@ -1450,12 +1450,16 @@ Supposons que vous voulez comparer le dernier commit avec le fichier du commit `
 
 ```sh
 $ git diff HEAD:path_to_file/file c5f567:path_to_file/file
+# ou
+$ git diff HEAD c5f567 -- path_to_file/file
 ```
 
 Il en est de même pour les branches :
 
 ```sh
 $ git diff main:path_to_file/file staging:path_to_file/file
+# ou
+$ git diff main staging -- path_to_file/file
 ```
 
 ### Je veux que Git ignore les changements d'un fichier spécifique

--- a/README_ja.md
+++ b/README_ja.md
@@ -1873,12 +1873,16 @@ $ git push origin refs/tags/<tag-name>
 
 ```sh
 $ git diff HEAD:path_to_file/file c5f567:path_to_file/file
+# または
+$ git diff HEAD c5f567 -- path_to_file/file
 ```
 
 ブランチでも同様です。
 
 ```sh
 $ git diff main:path_to_file/file staging:path_to_file/file
+# または
+$ git diff main staging -- path_to_file/file
 ```
 
 ### 特定のファイルの変更を無視したい

--- a/README_kr.md
+++ b/README_kr.md
@@ -1409,12 +1409,16 @@ c5f567 한 단계전으로 복구하고 싶다면, c5f567~1로 적어줘요:
 
 ```sh
 $ git diff HEAD:path_to_file/file c5f567:path_to_file/file
+# 아니면 짧게:
+$ git diff HEAD c5f567 -- path_to_file/file
 ```
 
 브랜치도 같은 방법으로:
 
 ```sh
 $ git diff main:path_to_file/file staging:path_to_file/file
+# 아니면 짧게:
+$ git diff main staging -- path_to_file/file
 ```
 
 ## 설정

--- a/README_ru.md
+++ b/README_ru.md
@@ -1681,12 +1681,16 @@ $ git push origin refs/tags/<tag-name>
 
 ```sh
 $ git diff HEAD:path_to_file/file c5f567:path_to_file/file
+# или
+$ git diff HEAD c5f567 -- path_to_file/file
 ```
 
 Аналогично для веток:
 
 ```sh
 $ git diff main:path_to_file/file staging:path_to_file/file
+# или
+$ git diff main staging -- path_to_file/file
 ```
 
 ### Я хочу, чтобы Git игнорировал изменения в определенном файле

--- a/README_vi.md
+++ b/README_vi.md
@@ -1776,12 +1776,16 @@ Giả sử bạn muốn so sánh commit cuối cùng với tệp từ commit c5f
 
 ```sh
 $ git diff HEAD:path_to_file/file c5f567:path_to_file/file
+# hoặc
+$ git diff HEAD c5f567 -- path_to_file/file
 ```
 
 Cũng giống khi so sánh nhánh nhánh:
 
 ```sh
 $ git diff main:path_to_file/file staging:path_to_file/file
+# hoặc
+$ git diff main staging -- path_to_file/file
 ```
 
 ### Tôi muốn Git bỏ qua những thay đổi đối với một tệp cụ thể


### PR DESCRIPTION
There is one more way to show changes in the same file between two different commits or branches.
It looks simpler: 

```bash
'git diff' [options] <commit> <commit> [--] [<path>...]
```

This should work for git version 2.13.0:
https://github.com/git/git/blob/v2.13.0/Documentation/git-diff.txt#L14

This section doesn't exist in [README_es.md](https://github.com/k88hudson/git-flight-rules/blob/master/README_es.md), [README_zh-CN.md](https://github.com/k88hudson/git-flight-rules/blob/master/README_zh-CN.md) and [README_zh-TW.md](https://github.com/k88hudson/git-flight-rules/blob/master/README_zh-TW.md) so I didn’t add anything in these files.