### PR TITLE
Add method to change authors for multiple commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,14 @@ An alternative is to correctly configure your author settings in `git config --g
 $ git commit --amend --reset-author --no-edit
 ```
 
-If you need to change all of history, see the man page for `git filter-branch`.
+If you need to change for multiple commits, you can use
+
+```sh
+$ git -c rebase.instructionFormat='%s%nexec GIT_COMMITTER_DATE="%cD" GIT_AUTHOR_DATE="%aD" git commit --amend --no-edit --reset-author' rebase -r <commit>
+```
+
+`<commit>` is a commit before all your bad commits. If you need to change all of history in the current branch including the root of the branch, put `--root` there instead.
+Note this will change the history and a force push is required.
 
 ### I want to remove a file from the previous commit
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,9 @@ $ git -c rebase.instructionFormat='%s%nexec GIT_COMMITTER_DATE="%cD" GIT_AUTHOR_
 ```
 
 `<commit>` is a commit before all your bad commits. If you need to change all of history in the current branch including the root of the branch, put `--root` there instead.
+
+If you need to change all of history, see the man page for `git filter-branch`.
+
 Note this will change the history and a force push is required.
 
 ### I want to remove a file from the previous commit


### PR DESCRIPTION
Add one of methods to change authors for multiple commits.

I'm not sure if "single commit" and "multiple commits" should be split into two `h4`-level sections, because this is quite short and seems not reducing readability.