### PR TITLE
Add Compress PDF tool – free, browser-based, no uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ All commands should work for at least git version 2.13.0. See the [git website](
   - [GUI Clients](#gui-clients)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+- [Compress PDF – NoCodeVista](https://nocodevista.com/tools/compress-pdf) - Free browser-based PDF compressor — reduce file size up to 90%, no uploads, 100% private.
 
 ## Repositories
 


### PR DESCRIPTION
Hi! I'd like to suggest adding **[Compress PDF](https://nocodevista.com/tools/compress-pdf)** to this list.

Free browser-based PDF compressor — reduce PDF file size up to 90% without losing quality, no uploads needed.

It's free, privacy-first (runs entirely in the browser — no file uploads), and no sign-up needed. Happy to adjust the placement if there's a better section. Thanks!